### PR TITLE
remove ping checks - not needed with budgetkey-k8s environment

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -5,13 +5,5 @@ echo "HELLO WORLD!"
 ls -la /var/datapackages 
 chmod 777 /var/datapackages 
 
-SERVICES="open-budget-data-api budgetkey-app-search open-budget-search-api budgetkey-app-generic-item budgetkey-app-main-page"
-
-
-for x in $SERVICES
-do
-  while ! ping -c1 $x &>/dev/null; do :; done && echo "$x is UP"
-done
-
 echo "NGINX STARTING"
 nginx -g "daemon off;"


### PR DESCRIPTION
budgetkey-k8s environment has services for all endpoints, regardless of the underlying deployment - OpenBudget/budgetkey-k8s#8

no need for ping checks (better not to have them IMO - causes unnecesary delay and potential complications..)